### PR TITLE
Changes due to http://stackoverflow.com/questions/31856363/boost-shared-memory-vector-of-char/32040468#32040468

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(EXEC_NAME nodetest)
 
 find_package(ALSA) #alsa
 find_package (Threads) #pthread
-find_package(Boost 1.58.0) #boost
+find_package(Boost 1.54.0) #boost
 
 set(INCLUDE_DIR ./include)
 


### PR DESCRIPTION
In addition to what everyone else has been saying, 

 * you had an error in the samples -> byte count conversion. This lead to half of the output being uninitialized data

        void lambda_callback(char *c, int rc) {
            this->sample_count_ += rc;
            this->output_file_.write(c, rc * 2);
        }

    becomes

        void lambda_callback(char *c, int rc) {
            this->sample_count_ += rc/2;
            this->output_file_.write(c, rc);
        }

   > **NOTE** see also `rc*2` in `to_node` below

 * you inserted the strings into the vector _at the front_ - this leads to chunks of audio being output in reverse order.

        void to_node(char *c, int rc) {
            CharAllocator charallocator(this->shm->get_segment_manager());
            StringAllocator stringallocator(this->shm->get_segment_manager());
            MyShmString mystring(charallocator);
            mystring = c;
            this->myshmvector->insert(this->myshmvector->begin(), mystring);
        }

    becomes

        void to_node(char *c, int rc) {
            _myshmvector->emplace_back(c, rc*2, shm->get_segment_manager());
        }

 * instead of relying on the fixed buffer size, you should actually use the string size when iterating the shared vector. Besides **don't use `strcpy` for binary data**:

        void listener() {
            lambda_class ctc("writer.wav");

            char *c = (char *) malloc(2048);

            boost::interprocess::managed_shared_memory segment(boost::interprocess::open_only, "MySharedMemory");
            MyShmStringVector *myvector = segment.find<MyShmStringVector>("myshmvector").first;


            for (MyShmStringVector::iterator it = myvector->begin(); it != myvector->end(); it++) {
                //strcpy(c, std::string(it->begin(), it->end()).c_str()); //HUHUH!?!
                strcpy(c, it->c_str());
                ctc.lambda_callback(c, 2048);
            }
        }

    becomes:

        void listener() {
            lambda_class ctc("writer.wav");

            char c[2048];

            boost::interprocess::managed_shared_memory segment(boost::interprocess::open_only, "MySharedMemory");
            MyShmStringVector *myvector = segment.find<MyShmStringVector>("myshmvector").first;

            for (MyShmStringVector::iterator it = myvector->begin(); it != myvector->end(); it++) {
                //strcpy(c, std::string(it->begin(), it->end()).c_str()); //HUHUH!?!
                assert(it->size()<=4096);
                memcpy(c, it->c_str(), it->size());
                ctc.lambda_callback(c, it->size());
            }
        }

 * Don't `malloc` in c++. You had those leaked

 * your test scenario is racy (but I assume you knew that and this was for simplicity?)

 * Instead of "magic" file re-open, just `seekp`:

        this->output_file_.close();
        this->output_file_.open(this->filename_, std::ios::binary | std::ios::in);

   becomes 

        output_file_.seekp(0ul);

**<kbd>[Pull Request on GitHub]()</kbd>**

    commit 660208ff3fe792112ccae70a61e8a2442a853664
    Author: Seth Heeren <sgheeren@gmail.com>
    Date:   Mon Aug 17 00:13:31 2015 +0200
    
        Fixes, now
        
            ./nodetest & sleep 6; ./nodetest 1; fg; md5sum *.wav
        
        results in proper identical files, e.g.
        
            $ ./nodetest & sleep 6; ./nodetest 1; fg; md5sum *.wav
            [1] 12350
            Go
            ./nodetest
            ff083a6344d7037da9c4f6d730239f30  listener_vector.wav
            ff083a6344d7037da9c4f6d730239f30  listener.wav
            ff083a6344d7037da9c4f6d730239f30  writer.wav
    
    commit 04a5dec3da322dab196bfe568f52db6d9ed68b43
    Author: Seth Heeren <sgheeren@gmail.com>
    Date:   Sun Aug 16 23:30:40 2015 +0200
    
        we have repro

## `main.cc`

    #include <boost/interprocess/managed_shared_memory.hpp>
    #include <boost/interprocess/containers/vector.hpp>
    #include <boost/interprocess/containers/string.hpp>
    #include <boost/interprocess/allocators/allocator.hpp>
    #include <iostream>
    #include <atomic>
    #include <future>
    
    #include <iostream>
    #include <alsa_control.h>
    
    using std::cout;
    using std::endl;
    
    typedef boost::interprocess::allocator<char, boost::interprocess::managed_shared_memory::segment_manager> CharAllocator;
    typedef boost::interprocess::basic_string<char, std::char_traits<char>, CharAllocator> MyShmString;
    typedef boost::interprocess::allocator<MyShmString, boost::interprocess::managed_shared_memory::segment_manager> StringAllocator;
    typedef boost::interprocess::vector<MyShmString, StringAllocator> MyShmStringVector;
    
    
    class lambda_class {
    public:
        void lambda_callback(char *c, int rc) {
            this->sample_count_ += rc/2;
            this->output_file_.write(c, rc);
        }
    
        lambda_class(std::string filename) {
          this->filename_ = filename;
          this->sample_count_ = 0;
          this->output_file_.open(this->filename_, std::ios::binary);
          write_header_wav(this->output_file_, 16000, 16, MONO, 10000);
        }
    
        ~lambda_class() {
          /*
           *this->output_file_.close();
           *this->output_file_.open(this->filename_, std::ios::binary | std::ios::in);
           */
          output_file_.seekp(0ul);
          write_header_wav(this->output_file_, 16000, 16, MONO, this->sample_count_);
        }
    
    private:
        std::string filename_;
        int sample_count_;
        std::ofstream output_file_;
        lambda_class(const lambda_class &a) = delete;
    };
    
    class input_class {
    public:
        input_class() {
            boost::interprocess::shared_memory_object::remove("MySharedMemory");
            this->shm = new boost::interprocess::managed_shared_memory(boost::interprocess::create_only, "MySharedMemory",
                    1000000);
            CharAllocator charallocator(this->shm->get_segment_manager());
            StringAllocator stringallocator(this->shm->get_segment_manager());
            this->myshmvector = shm->construct<MyShmStringVector>("myshmvector")(stringallocator);
        };
    
        ~input_class() {
            lambda_class lc("listener_vector.wav");
            char c[4096];
            for (MyShmStringVector::iterator it = this->myshmvector->begin(); it != this->myshmvector->end(); it++) {
                assert(it->size()<=sizeof(c));
                memcpy(c, it->c_str(), it->size());
                lc.lambda_callback(c, it->size());
            }
            boost::interprocess::shared_memory_object::remove("MySharedMemory");
            shm->destroy_ptr(this->myshmvector);
        }
    
        void to_node(char *c, int rc) {
            this->myshmvector->emplace_back(c, rc*2, shm->get_segment_manager());
        }
    
    private:
        boost::interprocess::managed_shared_memory *shm;
        MyShmStringVector *myshmvector;
    };
    
    void listener() {
        lambda_class ctc("writer.wav");
    
        char c[4096];
    
        boost::interprocess::managed_shared_memory segment(boost::interprocess::open_only, "MySharedMemory");
        MyShmStringVector *myvector = segment.find<MyShmStringVector>("myshmvector").first;
    
        for (MyShmStringVector::iterator it = myvector->begin(); it != myvector->end(); it++) {
            //strcpy(c, std::string(it->begin(), it->end()).c_str()); //HUHUH!?!
            assert(it->size()<=sizeof(c));
            memcpy(c, it->c_str(), it->size());
            ctc.lambda_callback(c, it->size());
        }
    }
    
    int main(int argc, char **argv) {
        alsa_control ac(16000, 2048, 16, MONO);
    
        if (argc == 1) {
            input_class ic;
            ac.listen_with_callback(std::bind(&input_class::to_node, &ic, std::placeholders::_1, std::placeholders::_2), "listener");
            sleep(5);
            ac.stop();
            cout << "Go" << endl;
            sleep(10);
        } else {
            //    std::atomic<bool> done(false);
            auto th = std::async(std::launch::async, listener);
            //    done.store(true, std::memory_order_relaxed);
            th.get();
        }
        return 0;
    }

